### PR TITLE
point to circle/circleci-images for new issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 Dockerfiles for [CircleCI's convenience Docker images](https://hub.docker.com/r/circleci), built via https://github.com/circleci/circleci-images
 
 This repository's `master` branch tracks images pushed to https://hub.docker.com/r/circleci; its `staging` branch tracks images pushed to https://hub.docker.com/r/ccistaging.
+
+## Submitting Issues
+Please submit any issues or feature requests against https://github.com/circleci/circleci-images/issues


### PR DESCRIPTION
Seeing new issues against this Repo, but seems we should be encouraging issues, even PRs against the main repo in circle proper.