### PR TITLE
Install Android NDK to support API 30

### DIFF
--- a/android/images/api-30-ndk/Dockerfile
+++ b/android/images/api-30-ndk/Dockerfile
@@ -201,7 +201,7 @@ RUN sdkmanager \
 # API_LEVEL string gets replaced by m4
 RUN sdkmanager "platforms;android-30"
 
-ARG ndk_version=android-ndk-r20
+ARG ndk_version=android-ndk-r21e
 ARG android_ndk_home=/opt/android/${ndk_version}
 
 # install NDK


### PR DESCRIPTION
The current installed NDK `r20` does not support Android API 30, as this is an Android 30 NDK image, it would be best to upgrade to `r21e` to allow usage of API 30 NDK APIs.